### PR TITLE
Support custom jquery resource url

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ publish views
 ```sh
 php artisan vendor:publish --tag="filament-timepicker-views"
 ```
+
+publish config
+
+```sh
+php artisan vendor:publish --tag="filament-timepicker-config" 
+```
+
 ```php
 use HusamTariq\FilamentTimePicker\Forms\Components\TimePickerField;
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "husam-tariq/filament-timepicker",
+    "name": "littlehans8/filament-timepicker",
     "description": "Filament Time Picker Field",
     "type": "library",
-    "homepage": "https://github.com/husam-tariq/filament-timepicker",
+    "homepage": "https://github.com/LittleHans8/filament-timepicker",
     "require": {
         "php": "^8.0",
         "filament/filament": "*"
@@ -14,8 +14,8 @@
     },
     "authors": [
         {
-            "name": "husam-tariq",
-            "email": "hu22am1@gmail.com"
+            "name": "littlehans",
+            "email": "littlehans8@gmail.com"
         }
     ],
     "extra": {

--- a/config/filament-timepicker.php
+++ b/config/filament-timepicker.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'jquery_min'=> 'https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js',
+];

--- a/src/FilamentTimePickerServiceProvider.php
+++ b/src/FilamentTimePickerServiceProvider.php
@@ -10,15 +10,20 @@ class FilamentTimePickerServiceProvider extends PluginServiceProvider
     protected array $styles = [
         'timepicker.min' => __DIR__ . '/../public/dist/timepicker.min.css'
     ];
-    protected array $beforeCoreScripts = [
-        'jquery.min' => 'https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js',
-        'timepicker' => __DIR__ . '/../public/dist/timepicker.js',
-    ];
 
     public function configurePackage(Package $package): void
     {
         $package
             ->name('filament-timepicker')
-            ->hasViews();
+            ->hasViews()
+            ->hasConfigFile();
+    }
+
+    protected function getBeforeCoreScripts(): array
+    {
+        return [
+            'jquery.min' => config('filament-timepicker.jquery_min', 'https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js'),
+            'timepicker' => __DIR__ . '/../public/dist/timepicker.js',
+        ];
     }
 }


### PR DESCRIPTION
In my country, google-related services are disabled, which makes the jquery component inaccessible. So I added a new configuration file so that I can customize the jquery url